### PR TITLE
Fix local fill limiter ignoring 0

### DIFF
--- a/worlds/tunic/__init__.py
+++ b/worlds/tunic/__init__.py
@@ -229,7 +229,7 @@ class TunicWorld(World):
             else:
                 self.options.local_fill.value = 0
 
-        if self.options.local_fill > 0 and self.settings.limit_local_fill:
+        if self.options.local_fill => 0 and self.settings.limit_local_fill:
             # discard grass from non_local if it's meant to be limited
             self.options.non_local_items.value.discard("Grass")
             if self.multiworld.players > 1:


### PR DESCRIPTION
Without the change, if local fill is set to 0, it won't trigger the host.yaml limiter thing